### PR TITLE
Fix branch name in actions workflow

### DIFF
--- a/.github/workflows/function_test.yml
+++ b/.github/workflows/function_test.yml
@@ -5,9 +5,9 @@ name: Run tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
For some reason, GitHub changed the default name of a new repository from `master` to `main`. The Actions workflow is configured to (only) work on a branch called `master` (which doesn't exist in the upstream repository) . This PR changes the configuration to work on the `main` branch.